### PR TITLE
newAlramBot.py print문 및 write문 수정

### DIFF
--- a/personal_project/newAlramBot.py
+++ b/personal_project/newAlramBot.py
@@ -92,7 +92,7 @@ async def major_notice_CSE(channels):
                     now = datetime.now()
 
                     print("-------------------------------------------------------------------------------------")
-                    print("현재 major_num 값과 major_num_compared 값\n" + str(major_num), "||", major_num_compared, "||",now)
+                    print("현재 컴소과 major_num 값과 major_num_compared 값\n" + str(major_num), "||", major_num_compared, "||",now)
                     print("-------------------------------------------------------------------------------------\n")
 
                     if (major_num_compared == major_num + 1):
@@ -122,7 +122,7 @@ async def major_notice_CSE(channels):
                     
                     elif (major_num_compared == major_num - 1):
                         with open("removed notice.txt", "a+", encoding="utf8") as report_file:
-                            report_file.write("학과 공지가 삭제 되었음" + "\n")
+                            report_file.write("컴소과 학과 공지가 삭제 되었음" + "\n")
 
                         for channel in channels:
                             await channel.send("학과 공지가 삭제되었음\n")
@@ -153,7 +153,7 @@ async def major_notice_ICE(channels):
                     now = datetime.now()
 
                     print("-------------------------------------------------------------------------------------")
-                    print("현재 major_num 값과 major_num_compared 값\n" + str(major_num), "||", major_num_compared, "||",now)
+                    print("현재 정통과 major_num 값과 major_num_compared 값\n" + str(major_num), "||", major_num_compared, "||",now)
                     print("-------------------------------------------------------------------------------------\n")
 
                     if (major_num_compared == major_num + 1):
@@ -181,7 +181,7 @@ async def major_notice_ICE(channels):
                     
                     elif (major_num_compared == major_num - 1):
                         with open("removed notice.txt", "a+", encoding="utf8") as report_file:
-                            report_file.write("학과 공지가 삭제 되었음" + "\n")
+                            report_file.write("정통과 학과 공지가 삭제 되었음" + "\n")
 
                         for channel in channels:
                             await channel.send("학과 공지가 삭제되었음\n")


### PR DESCRIPTION
서버에서 코드 실행 후 console창의 log 확인 결과
학과공지 비교시 어느 과의 공지를 비교하는지 확인이 어려운 상황 발생

-> major_notice_CSE 와 major_notice_ICE 함수의 print문에 각 함수가 비교하는 학과명을 명시하고
추후 removed notice.txt 확인 시에도 어느 과의 공지가 삭제되었는지 명확하게 하기 위해 write문에도 학과명 추가함.

![image](https://github.com/user-attachments/assets/769b2753-2a89-4388-8aa9-b2d5e9777858)
